### PR TITLE
Replace continent_code AS to AP country code (Asia/Pacific Region)

### DIFF
--- a/geolite2legacy.py
+++ b/geolite2legacy.py
@@ -138,6 +138,14 @@ class RadixTree(object):
         if locationsfile:
             for row in csv.DictReader(locationsfile):
                 geoname_id = row['geoname_id']
+                # Replace continent_code AS to AP country code (Asia/Pacific Region)
+                # This prevent collision with country code AS,"American Samoa"
+                # when country_iso_code is absent.
+                # See https://dev.maxmind.com/geoip/legacy/codes/iso3166/
+                continent_code = row['continent_code']
+                country_iso_code = row['country_iso_code']
+                if continent_code == "AS" and country_iso_code == "":
+                    row['continent_code'] = "AP"
                 locations[geoname_id] = row
 
         for nets, data in self.gen_nets(locations, outfile):


### PR DESCRIPTION
Thanks for your work!

I tested a lot of IP4 subnets (175075) on the converted GeoIP.dat (in this test GeoIPv2 out) with original GeoIP.dat (GeoIPv1 out) and found bug:
```geodns-stage-3# ./geoip_conv_test.sh ip4
Records mismatch for 104.199.206.0 GeoIPv2: AS, GeoIPv1: AP
Records mismatch for 169.145.197.0 GeoIPv2: AS, GeoIPv1: AP

Request in legacy DB:
geodns-stage-3# geoiplookup -f /usr/local/share/GeoIP/GeoIP.dat 104.199.206.0
GeoIP Country Edition: AP, Asia/Pacific Region

geodns-stage-3# geoiplookup -f /usr/local/share/GeoIP/GeoIP.dat 169.145.197.0
GeoIP Country Edition: AP, Asia/Pacific Region
```
This happen when in GeoIP2-Country-Locations-en.csv is no country_iso_code description:
6255147,en,AS,Asia,,,0

From https://dev.maxmind.com/geoip/legacy/codes/iso3166/ this country code describe:
AS,"American Samoa"

This is mistake. I guess we need to use old code AP for this case:
AP,"Asia/Pacific Region"

Also programs that work with geoipv1 do not expect to see the code AS.

Thanks!
