### PR TITLE
add custom comment in country and asn files

### DIFF
--- a/geolite2legacy.py
+++ b/geolite2legacy.py
@@ -339,7 +339,7 @@ class CountryRadixTree(RadixTree):
             f.write(self.serialize_node(node.rhs))
 
         f.write(struct.pack('B', 0x00) * 3)
-        f.write(b'geolite2legacy.py')  # .dat file comment - can be anything
+        f.write(datfilecomment.encode('ascii'))  # .dat file comment - can be anything
         f.write(struct.pack('B', 0xff) * 3)
         f.write(struct.pack('B', self.edition))
         f.write(self.encode_rec(len(self.segments), self.segreclen))

--- a/geolite2legacy.py
+++ b/geolite2legacy.py
@@ -221,7 +221,7 @@ class ASNRadixTree(RadixTree):
             yield nets, (serialize_text(entry),)
 
     def encode(self, data):
-        return data + b'\0'
+        return data + b'\0\0\0'
 
 
 class ASNv6RadixTree(ASNRadixTree):


### PR DESCRIPTION
This fix adds the custom comment of the file which includes the version number to the country and asn files. before this it was only added to the city file.